### PR TITLE
Building multi-arch Docker image using debian as base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,15 @@
 name: Build/Test/Release
 on: [push]
 env:
-  EMULATOR_TAG: 0.14.0
+  EMULATOR_TAG: 0.14.0-bullseye
   ROM_VERSION: v0.16.0
   KERNEL_VERSION: v0.16.0
   LINUX_VERSION: 5.15.63-ctsi-2
   ROOTFS_VERSION: v0.17.0
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 jobs:
   build:
     name: Build
@@ -17,41 +21,24 @@ jobs:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Setup docker image tags
-        id: docker_image_tags
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ secrets.DOCKER_ORGANIZATION }}/server-manager
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{version}},enable=${{startsWith(github.ref, 'refs/tags/v')}}
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Ubuntu based docker image
+      - name: Build Debian based docker image
         uses: docker/build-push-action@v4
         with:
           file: Dockerfile
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ steps.docker_image_tags.outputs.tags }}
           push: false
           load: true
-          cache-from: type=gha,scope=ubuntu
-          cache-to: type=gha,mode=max,scope=ubuntu
+          cache-from: type=gha,scope=docker
+          cache-to: type=gha,mode=max,scope=docker
           build-args: |
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
-            EMULATOR_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+            EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}
 
   test-ioctl-echo-loop:
@@ -65,31 +52,25 @@ jobs:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Ubuntu based docker image
+      - name: Build Debian based docker image
         uses: docker/build-push-action@v4
         with:
           file: Dockerfile
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:devel
+          tags: ${{ github.repository_owner }}/server-manager:devel
           push: false
           load: true
-          cache-from: type=gha,scope=ubuntu
-          cache-to: type=gha,mode=max,scope=ubuntu
+          cache-from: type=gha,scope=docker
+          cache-to: type=gha,mode=max,scope=docker
           build-args: |
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
-            EMULATOR_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+            EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}
 
       - name: Build installer stage docker image
@@ -100,14 +81,14 @@ jobs:
           target: installer
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer
+          tags: ${{ github.repository_owner }}/server-manager:installer
           push: false
           load: true
-          cache-from: type=gha,scope=ubuntu
-          cache-to: type=gha,mode=max,scope=ubuntu
+          cache-from: type=gha,scope=docker
+          cache-to: type=gha,mode=max,scope=docker
           build-args: |
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
-            EMULATOR_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+            EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}
 
       - name: Download [rootfs.ext2]
@@ -116,7 +97,7 @@ jobs:
           repository: ${{ github.repository_owner }}/image-rootfs
           tag: ${{ env.ROOTFS_VERSION }}
           file: rootfs-${{ env.ROOTFS_VERSION }}.ext2
-          token: ${{ secrets.CI_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download [kernel.bin]
         uses: Legion2/download-release-action@v2.1.0
@@ -124,7 +105,7 @@ jobs:
           repository: ${{ github.repository_owner }}/image-kernel
           tag: ${{ env.KERNEL_VERSION }}
           file: linux-${{ env.LINUX_VERSION }}.bin
-          token: ${{ secrets.CI_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download [rom.bin]
         uses: Legion2/download-release-action@v2.1.0
@@ -132,7 +113,7 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-emulator-rom
           tag: ${{ env.ROM_VERSION }}
           file: rom-${{ env.ROM_VERSION }}.bin
-          token: ${{ secrets.CI_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Move images to cartesi images folder
         run: |
@@ -146,11 +127,11 @@ jobs:
         run: |
           docker volume create --name server-manager-root
           docker network create mynetwork
-          docker run --rm -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer chown -R cartesi:cartesi /tmp/server-manager-root
-          docker run --rm -u cartesi:cartesi -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer make create-machines
-          docker run --rm -p 5001:5001 -h server-manager-container --name server-manager-container --network mynetwork -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:devel &
+          docker run --rm -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:installer chown -R cartesi:cartesi /tmp/server-manager-root
+          docker run --rm -u cartesi:cartesi -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:installer make create-machines
+          docker run --rm -p 5001:5001 -h server-manager-container --name server-manager-container --network mynetwork -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:devel &
           timeout 20 bash -c 'while ! nc -q0 127.0.0.1 5001 < /dev/null > /dev/null 2>&1; do sleep 1; done'
-          docker run --rm -u cartesi:cartesi -h test-container --name test-container --network mynetwork -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer make run-test-server-manager MANAGER_ADDRESS=server-manager-container:5001
+          docker run --rm -u cartesi:cartesi -h test-container --name test-container --network mynetwork -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:installer make run-test-server-manager MANAGER_ADDRESS=server-manager-container:5001
           docker kill server-manager-container
 
   test-echo-dapp:
@@ -174,21 +155,21 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Ubuntu based docker image
+      - name: Build Debian based docker image
         uses: docker/build-push-action@v4
         with:
           file: Dockerfile
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:devel
+          tags: ${{ github.repository_owner }}/server-manager:devel
           push: false
           load: true
-          cache-from: type=gha,scope=ubuntu
-          cache-to: type=gha,mode=max,scope=ubuntu
+          cache-from: type=gha,scope=docker
+          cache-to: type=gha,mode=max,scope=docker
           build-args: |
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
-            EMULATOR_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+            EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}
 
       - name: Build installer stage docker image
@@ -199,14 +180,14 @@ jobs:
           target: installer
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer
+          tags: ${{ github.repository_owner }}/server-manager:installer
           push: false
           load: true
-          cache-from: type=gha,scope=ubuntu
-          cache-to: type=gha,mode=max,scope=ubuntu
+          cache-from: type=gha,scope=docker
+          cache-to: type=gha,mode=max,scope=docker
           build-args: |
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
-            EMULATOR_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+            EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}
 
       - name: Download [rootfs.ext2]
@@ -215,7 +196,7 @@ jobs:
           repository: ${{ github.repository_owner }}/image-rootfs
           tag: ${{ env.ROOTFS_VERSION }}
           file: rootfs-${{ env.ROOTFS_VERSION }}.ext2
-          token: ${{ secrets.CI_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download [kernel.bin]
         uses: Legion2/download-release-action@v2.1.0
@@ -223,7 +204,7 @@ jobs:
           repository: ${{ github.repository_owner }}/image-kernel
           tag: ${{ env.KERNEL_VERSION }}
           file: linux-${{ env.LINUX_VERSION }}.bin
-          token: ${{ secrets.CI_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download [rom.bin]
         uses: Legion2/download-release-action@v2.1.0
@@ -231,7 +212,7 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-emulator-rom
           tag: ${{ env.ROM_VERSION }}
           file: rom-${{ env.ROM_VERSION }}.bin
-          token: ${{ secrets.CI_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Move images to cartesi images folder
         run: |
@@ -245,11 +226,11 @@ jobs:
         run: |
           docker volume create --name server-manager-root
           docker network create mynetwork
-          docker run --rm -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer chown -R cartesi:cartesi /tmp/server-manager-root
-          docker run --rm -u cartesi:cartesi -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer make create-machines rollup_init=yes
-          docker run --rm -p 5001:5001 -h server-manager-container --name server-manager-container --network mynetwork -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:devel &
+          docker run --rm -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:installer chown -R cartesi:cartesi /tmp/server-manager-root
+          docker run --rm -u cartesi:cartesi -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:installer make create-machines rollup_init=yes
+          docker run --rm -p 5001:5001 -h server-manager-container --name server-manager-container --network mynetwork -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:devel &
           timeout 20 bash -c 'while ! nc -q0 127.0.0.1 5001 < /dev/null > /dev/null 2>&1; do sleep 1; done'
-          docker run --rm -u cartesi:cartesi -h test-container --name test-container --network mynetwork -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer make run-test-server-manager MANAGER_ADDRESS=server-manager-container:5001
+          docker run --rm -u cartesi:cartesi -h test-container --name test-container --network mynetwork -v /opt/cartesi/share/images:/opt/cartesi/share/images -v server-manager-root:/tmp/server-manager-root ${{ github.repository_owner }}/server-manager:installer make run-test-server-manager MANAGER_ADDRESS=server-manager-container:5001
           docker kill server-manager-container
 
   static-analysis:
@@ -273,7 +254,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Ubuntu based docker image
+      - name: Build Debian based docker image
         uses: docker/build-push-action@v4
         with:
           file: Dockerfile
@@ -281,21 +262,21 @@ jobs:
           target: installer
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer
+          tags: ${{ github.repository_owner }}/server-manager:installer
           push: false
           load: true
-          cache-from: type=gha,scope=ubuntu
-          cache-to: type=gha,mode=max,scope=ubuntu
+          cache-from: type=gha,scope=docker
+          cache-to: type=gha,mode=max,scope=docker
           build-args: |
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
-            EMULATOR_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+            EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}
 
       - name: Check format
-        run: docker run --rm ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer make check-format
+        run: docker run --rm ${{ github.repository_owner }}/server-manager:installer make check-format
 
       - name: Lint
-        run: docker run --rm ${{ secrets.DOCKER_ORGANIZATION }}/server-manager:installer make lint -j$(nproc)
+        run: docker run --rm ${{ github.repository_owner }}/server-manager:installer make lint -j$(nproc)
 
   release:
     name: Publish Docker image
@@ -309,11 +290,13 @@ jobs:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
 
-      - name: Setup ubuntu docker image tags
-        id: ubuntu_docker_image_tags
+      - name: Setup debian docker image tags
+        id: docker_image_tags
         uses: docker/metadata-action@v4
         with:
-          images: ${{ secrets.DOCKER_ORGANIZATION }}/server-manager
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/server-manager
+            name=docker.io/${{ github.repository_owner }}/server-manager,enable=${{startsWith(github.ref, 'refs/tags/v')}}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -328,19 +311,26 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build Ubuntu based docker image
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Debian based docker image
         uses: docker/build-push-action@v4
         with:
           file: Dockerfile
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ steps.ubuntu_docker_image_tags.outputs.tags }}
+          tags: ${{ steps.docker_image_tags.outputs.tags }}
           push: true
           load: false
-          cache-from: type=gha,scope=ubuntu
-          cache-to: type=gha,mode=max,scope=ubuntu
+          cache-from: type=gha,scope=docker
+          cache-to: type=gha,mode=max,scope=docker
           build-args: |
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
-            EMULATOR_REPOSITORY=${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+            EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,13 +318,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: depot/setup-action@v1
       - name: Build Debian based docker image
-        uses: docker/build-push-action@v4
+        uses: depot/build-push-action@v1
         with:
           file: Dockerfile
           context: .
-          builder: ${{ steps.buildx.outputs.name }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_image_tags.outputs.tags }}
           push: true
           load: false
@@ -334,3 +334,4 @@ jobs:
             RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
             EMULATOR_REPOSITORY=${{ github.repository_owner }}/machine-emulator
             EMULATOR_TAG=${{ env.EMULATOR_TAG }}
+          project: ${{ vars.DEPOT_PROJECT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && \
         libreadline-dev libboost-coroutine-dev libboost-context-dev \
         libboost-filesystem-dev libboost-log-dev libssl-dev libc-ares-dev zlib1g-dev \
         ca-certificates automake libtool patchelf cmake pkg-config lua5.3 liblua5.3-dev \
-        libcrypto++-dev clang-tidy-14 clang-format-14 && \
-    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 120 && \
-    update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 120 && \
+        libcrypto++-dev clang-tidy-13 clang-format-13 && \
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 120 && \
+    update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 120 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/server-manager

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> :warning: The Cartesi team keeps working internally on the next version of this repository, following its regular development roadmap. Whenever there's a new version ready or important fix, these are published to the public source tree as new releases.
-
 # Cartesi Server-Manager
 
 The Cartesi Server-Manager is a microservice that serves as an interface between the Remote Cartesi Machine (RCM) and other components of the Cartesi Rollup node. It is designed to simplify the communication between the RCM and the rest of the Cartesi node. It's written in C/C++ with POSIX dependencies restricted to the terminal and process facilites. Currently, it is distributed as a docker image.
@@ -38,18 +36,21 @@ Obs: Please note that Apple Clang Version number does not follow upstream LLVM/C
 
 #### Ubuntu 22.04
 
-```
+```shell
 sudo apt-get install build-essential automake libtool patchelf cmake pkg-config wget git libreadline-dev libboost-coroutine-dev libboost-context-dev libboost-filesystem-dev libssl-dev openssl libc-ares-dev zlib1g-dev ca-certificates liblua5.3-dev
 ```
+
 #### MacOS
 
 ##### MacPorts
-```
+
+```shell
 sudo port install clang-14 automake boost libtool wget cmake pkgconfig c-ares zlib openssl lua
 ```
 
 ##### Homebrew
-```
+
+```shell
 brew install llvm@14 automake boost libomp wget cmake pkg-config c-ares zlib openssl lua@5.3
 ```
 
@@ -57,37 +58,37 @@ For `create-machines.lua` script to work it is expected that `lua5.3` binary is 
 
 ### Build
 
-```bash
-$ make submodules
-$ make dep
-$ make
+```shell
+make submodules
+make dep
+make
 ```
 
 Cleaning:
 
-```bash
-$ make depclean
-$ make clean
+```shell
+make depclean
+make clean
 ```
 
 ### Running Tests
 
 In order to run the tests for the Cartesi Server-Manager, it is essential to have a fully functional SDK installation located at `/opt/cartesi`. This installation enables the creation of test machines and the execution of the Remote Cartesi Machine. To create the test machines, use the following command:
 
-```bash
-$ make create-machines
+```shell
+make create-machines
 ```
 
 Once the test machines have been created, the Cartesi Server-Manager tests can be executed using the following command:
 
-```bash
-$ make test
+```shell
+make test
 ```
 
 ### Install
 
-```bash
-$ make install
+```shell
+make install
 ```
 
 ## Linter
@@ -100,15 +101,15 @@ We use clang-tidy 14 as the linter.
 
 You need to install the package clang-tidy-14 and set it as the default executable with update-alternatives.
 
-```bash
-$ apt install clang-tidy-14
-$ update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 120
+```shell
+apt install clang-tidy-14
+update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 120
 ```
 
 ### Running Lint
 
-```bash
-$ make lint -j$(nproc)
+```shell
+make lint -j$(nproc)
 ```
 
 ## Code format
@@ -121,21 +122,21 @@ We use clang-format to format the code base.
 
 You need to install the package clang-format-14 and set is as the default executable with update-alternatives.
 
-```bash
-$ apt install clang-format-14
-$ update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 120
+```shell
+apt install clang-format-14
+update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 120
 ```
 
 ### Formatting code
 
-```bash
-$ make format
+```shell
+make format
 ```
 
 ### Checking whether the code is formatted
 
-```bash
-$ make check-format
+```shell
+make check-format
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ We use clang-tidy 14 as the linter.
 
 #### Ubuntu 22.04
 
-You need to install the package clang-tidy-14 and set it as the default executable with update-alternatives.
+You need to install the package clang-tidy-13 and set it as the default executable with update-alternatives.
 
 ```shell
-apt install clang-tidy-14
-update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 120
+apt install clang-tidy-13
+update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-13 120
 ```
 
 ### Running Lint


### PR DESCRIPTION
- In the CI I used the `cartesi/machine-emulator:0.14.0-bullseye` as base.
- Needed to downgrade clang-tidy and clang-format to versions available in debian bullseye
- Final images built in depot.dev
- Minor styling changes in README