### PR TITLE
Add request metadata to exception logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Improved messages when there is a timeout
-- Improved messages when session is tainted
+- Improved error messages and logs
 - Added request metadata to log message of thrown exceptions
 
 ## [0.9.1] - 2024-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved messages when there is a timeout
 - Improved messages when session is tainted
+- Added request metadata to log message of thrown exceptions
 
 ## [0.9.1] - 2024-03-28
 ### Changed


### PR DESCRIPTION
Before this PR, the metadata sent along with a request to the server data did not appear in the logs that are generated when an exception happens in the process of servicing that request. After this PR, the metadata is included in the logs.